### PR TITLE
build: fix golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 8m


### PR DESCRIPTION
Adding timeout to golangci-lint when testing locally fixed this issue in my tests.
With the timeout set to 6m, the Linux tests passed, but not the Mac ones.
Trying to increase the timeout to 8m.