### PR TITLE
feat: add devenv devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "gh-runner-regger",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "ghcr.io/cachix/devenv:latest",
+
+	"remoteEnv": {
+		"GOPRIVATE": "github.com/reMarkable/*",
+		"GH_TOKEN": "${localEnv:GH_TOKEN}",
+		"TF_TOKEN_orbit_rm_guru": "${localEnv:GH_TOKEN}"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"./shared-ssh": {}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/shared-ssh/devcontainer-feature.json
+++ b/.devcontainer/shared-ssh/devcontainer-feature.json
@@ -1,0 +1,16 @@
+{
+    "name": "Shared SSH config",
+    "id": "shared-ssh",
+    "version": "0.1.0",
+    "description": "Sets up .ssh against a docker volume, so it will be shared between devcontainers",
+    "mounts": [
+        {
+            "source": "devcontainer_ssh",
+            "target": "/home/vscode/.ssh",
+            "type": "volume"
+        }
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/.devcontainer/shared-ssh/install.sh
+++ b/.devcontainer/shared-ssh/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Setup .ssh
+echo "Setting up shared ssh configuration..."
+sudo mkdir -p "${_REMOTE_USER_HOME}/.ssh"
+chown ${_REMOTE_USER}.${_REMOTE_USER} "${_REMOTE_USER_HOME}/.ssh"
+chmod 0700 "${_REMOTE_USER_HOME}/.ssh"
+echo "Done!"


### PR DESCRIPTION
add the ghcr.io/cachix/devenv devcontainer to simplify the use of devenv in Windows.